### PR TITLE
Mention how to combine FGenerators with SplittablesBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,9 @@ julia = "1"
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
+SplittablesBase = "171d559e-b47b-412a-8079-5efa626c420e"
+SplittablesTesting = "3bda5eb5-c32a-4f64-8618-df3be8968470"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "FLoops", "Test"]
+test = ["Documenter", "FLoops", "SplittablesBase", "SplittablesTesting", "Test"]

--- a/README.md
+++ b/README.md
@@ -74,3 +74,52 @@ x = 1
 x = 2
 x = 3
 ```
+
+## Adding fold protocol to existing type
+
+The `foldl` protocol can be implemented for an existing type `T`, by
+using the syntax `@fgenerator(foldable::T) do .. end`:
+
+```julia
+julia> struct OrganPipe <: Foldable
+           n::Int
+       end
+
+julia> @fgenerator(foldable::OrganPipe) do
+           n = foldable.n
+           @yieldfrom 1:n
+           @yieldfrom n-1:-1:1
+       end;
+
+julia> collect(OrganPipe(2))
+3-element Array{Int64,1}:
+ 1
+ 2
+ 1
+```
+
+## Defining parallelizable collection
+
+`@fgenerator` alone is not enough for using parallel loops on the
+collection.  However it can be easily supported by defining
+[`SplittablesBase.halve`](https://github.com/JuliaFolds/SplittablesBase.jl)
+and `length` (or `SplittablesBase.amount` if `length` is hard to
+define).  Since `halve` and `length` has to be implemented on the same
+existing type, `@fgenerator(...) do` notation as above should be used.
+Extending `OrganPipe` example above:
+
+```julia
+julia> using SplittablesBase
+
+julia> function SplittablesBase.halve(foldable::OrganPipe)
+           n = foldable.n
+           return (1:n, n-1:-1:1)
+       end;
+
+julia> Base.length(foldable::OrganPipe) = 2 * foldable.n - 1;
+
+julia> @floop for x in OrganPipe(2)
+           @reduce(s += x)
+       end
+       s
+```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ julia> collect(OrganPipe(2))
  1
 ```
 
+Note that inheriting `Foldable` is necessary only if using `Base` API
+such as `collect`.  It is not necessary when using just Transducers.jl
+API (including `FLoops.@floop`).
+
 ## Defining parallelizable collection
 
 `@fgenerator` alone is not enough for using parallel loops on the

--- a/README.md
+++ b/README.md
@@ -126,4 +126,5 @@ julia> @floop for x in OrganPipe(2)
            @reduce(s += x)
        end
        s
+4
 ```

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -83,9 +83,9 @@ version = "0.1.0"
 
 [[FLoops]]
 deps = ["Compat", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "c2e9c9514fba21f99f5563dd03b063ee46df36ef"
+git-tree-sha1 = "3ae136ac2ae98109e6c346cdecdbbe65e58d4e81"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
-version = "0.1.0"
+version = "0.1.3"
 
 [[Future]]
 deps = ["Random"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FGenerators = "4fd0377b-cfdc-4941-97f4-8d7ddbb8981e"
 FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
+SplittablesBase = "171d559e-b47b-412a-8079-5efa626c420e"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -83,9 +83,9 @@ version = "0.1.0"
 
 [[FLoops]]
 deps = ["Compat", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
-git-tree-sha1 = "c2e9c9514fba21f99f5563dd03b063ee46df36ef"
+git-tree-sha1 = "3ae136ac2ae98109e6c346cdecdbbe65e58d4e81"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
-version = "0.1.0"
+version = "0.1.3"
 
 [[Future]]
 deps = ["Random"]

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -222,6 +222,12 @@ git-tree-sha1 = "ab80edcbd61a44a4dc489d06ead964a863c0a898"
 uuid = "171d559e-b47b-412a-8079-5efa626c420e"
 version = "0.1.10"
 
+[[SplittablesTesting]]
+deps = ["SplittablesBase"]
+git-tree-sha1 = "960b66bc22d3c5790be892e9533220561064b339"
+uuid = "3bda5eb5-c32a-4f64-8618-df3be8968470"
+version = "0.1.0"
+
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/test/environments/main/Project.toml
+++ b/test/environments/main/Project.toml
@@ -2,5 +2,7 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FGenerators = "4fd0377b-cfdc-4941-97f4-8d7ddbb8981e"
 FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
+SplittablesBase = "171d559e-b47b-412a-8079-5efa626c420e"
+SplittablesTesting = "3bda5eb5-c32a-4f64-8618-df3be8968470"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"

--- a/test/test_non_foldable.jl
+++ b/test/test_non_foldable.jl
@@ -1,0 +1,30 @@
+module TestNonFoldable
+
+using FGenerators
+using FLoops
+using Test
+
+struct OrganPipe  # not inheriting `Foldable`
+    n::Int
+end
+
+@fgenerator(foldable::OrganPipe) do
+    n = foldable.n
+    @yieldfrom 1:n
+    @yieldfrom n-1:-1:1
+end
+
+@testset "n=$n" for (n, desired) in [
+    (2, [1, 2, 1]),
+    (3, [1, 2, 3, 2, 1]),
+    (4, [1:4; 3:-1:1]),
+    (5, [1:5; 4:-1:1]),
+]
+    actual = []
+    @floop for x in OrganPipe(n)
+        push!(actual, x)
+    end
+    @test actual == desired
+end
+
+end  # module

--- a/test/test_samples.jl
+++ b/test/test_samples.jl
@@ -1,6 +1,8 @@
 module TestSamples
 
 using FGenerators
+using SplittablesBase
+using SplittablesTesting
 using Test
 using Transducers: Map
 
@@ -24,6 +26,23 @@ end
         @yield i
     end
 end
+
+struct OrganPipe <: Foldable
+    n::Int
+end
+
+@fgenerator(foldable::OrganPipe) do
+    n = foldable.n
+    @yieldfrom 1:n
+    @yieldfrom n-1:-1:1
+end
+
+function SplittablesBase.halve(foldable::OrganPipe)
+    n = foldable.n
+    return (1:n, n-1:-1:1)
+end
+
+Base.length(foldable::OrganPipe) = 2 * foldable.n - 1
 
 @fgenerator function flatten2(a, b)
     @yieldfrom a
@@ -72,6 +91,8 @@ oneone() == [1]
 onetwothree() == [1, 2, 3]
 organpipe(2) == [1, 2, 1]
 organpipe(3) == [1, 2, 3, 2, 1]
+OrganPipe(2) == [1, 2, 1]
+OrganPipe(3) == [1, 2, 3, 2, 1]
 flatten2((1, 2), (3,)) == [1, 2, 3]
 Count(0, 2) == [0, 1, 2]
 Count(0, -1) == Int[]
@@ -102,5 +123,7 @@ end
     @test collect(f(args...; kwargs...)) ==′ desired
     @test collect(Map(identity), f(args...; kwargs...)) ==′ desired
 end
+
+SplittablesTesting.test_ordered(Any[OrganPipe(n) for n in 1:10])
 
 end  # module


### PR DESCRIPTION
## Commit Message
Mention how to combine FGenerators with SplittablesBase (#9)

The `OrganPipe` example with and without `<: Foldable` are tested
manually (by copying the code; for now).